### PR TITLE
Add icons and labels objects to the strategies

### DIFF
--- a/library.js
+++ b/library.js
@@ -136,6 +136,12 @@
 				url: '/auth/' + pluginStrategies[0].name,
 				callbackURL: '/auth/' + pluginStrategies[0].name + '/callback',
 				icon: 'fa-wordpress',
+				icons: {
+					normal: 'fa fa-wordpress'
+				},
+				labels: {
+					login: 'Wordpress'
+				},
 				scope: (pluginStrategies[0].scope || '').split(',')
 			});
 		}


### PR DESCRIPTION
It doesn't feel right.

```
				icons: {
                                         // this doesn't look right, but if I don't add the `fa` it's not shown, even this, is only shown on hover.
					normal: 'fa fa-wordpress'
				},
				labels: {
                                         // it feels like should be a configuration of the plugin? Since it's the label is shown on the button, 
					login: 'Wordpress'
				},
```

![Screenshot 2025-06-20 at 12 47 47](https://github.com/user-attachments/assets/c830547e-3d83-4e60-82df-7462c0a7fe87)
